### PR TITLE
[#7] Adding support for SEPA Creditor Identifier defined by the EPC

### DIFF
--- a/src/main/java/fr/marcwrobel/jbanking/creditor/CreditorIdentifier.java
+++ b/src/main/java/fr/marcwrobel/jbanking/creditor/CreditorIdentifier.java
@@ -1,0 +1,260 @@
+/**
+ * Copyright 2013 Marc Wrobel (marc.wrobel@gmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * 		http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package fr.marcwrobel.jbanking.creditor;
+
+import fr.marcwrobel.jbanking.IsoCountry;
+import fr.marcwrobel.jbanking.iban.IbanCheckDigit;
+
+import java.util.regex.Pattern;
+
+/**
+ * <p>
+ * A Creditor Identifier (CI) Code as specified by the
+ * <a href="http://www.europeanpaymentscouncil.eu/index.cfm/knowledge-bank/epc-documents/creditor-identifier-overview/">EPC</a>.
+ * </p>
+ * <p/>
+ * <p>
+ * CI structure:
+ * <ul>
+ * <li>Position 1-2 filled with the ISO country code.</li>
+ * <li>Position 3-4 filled with the check digit according to ISO 7064 Mod 97-10.</li>
+ * <li>Position 5-7 filled with the Creditor Business Code, if not used then filled with ZZZ.</li>
+ * <li>Position 8 onwards filled with the country specific part of the identifier being
+ * a national identifier of the Creditor, as defined by the National Community.</li>
+ * </ul>
+ * </p>
+ * <p/>
+ * <p>
+ * This class handles validation of the check digit and validation of the Creditor Identifier Structure described above without
+ * going into the validation of the national identifier.
+ * </p>
+ * <p/>
+ * <p>Instances of this class are immutable and are safe for use by multiple concurrent threads.</p>
+ *
+ * @author Charles Kayser
+ * @see <a href="http://www.europeanpaymentscouncil.eu/index.cfm/knowledge-bank/epc-documents/creditor-identifier-overview/">EPC Creditor Identifier Overview</a>
+ */
+public class CreditorIdentifier {
+
+    private static final String BASIC_REGEX = "[A-Za-z]{2}[0-9]{2}[A-Za-z0-9]{3}[A-Za-z0-9]+";
+    private static final Pattern BASIC_PATTERN = Pattern.compile(BASIC_REGEX);
+
+    private static final int COUNTRY_CODE_INDEX = 0;
+    private static final int COUNTRY_CODE_LENGTH = 2;
+    private static final int CHECK_DIGITS_INDEX = COUNTRY_CODE_INDEX + COUNTRY_CODE_LENGTH;
+    private static final int CHECK_DIGITS_LENGTH = 2;
+    private static final int CREDITOR_BUSINESS_CODE_INDEX = CHECK_DIGITS_INDEX + CHECK_DIGITS_LENGTH;
+    private static final int CREDITOR_BUSINESS_CODE_LENGTH = 3;
+    private static final int CREDITOR_NATIONAL_ID_INDEX = CREDITOR_BUSINESS_CODE_INDEX + CREDITOR_BUSINESS_CODE_LENGTH;
+
+    private final String creditorId;
+
+    /**
+     * Create a new Creditor Identifier from the given country code, the creditor business code
+     * and the creditor national id.
+     *
+     * @param country            A non null IsoCountry.
+     * @param businessCode       A non null String.
+     * @param creditorNationalId A non null String.
+     * @throws IllegalArgumentException                                          if either the IsoCountry or BBAN is null
+     * @throws fr.marcwrobel.jbanking.creditor.CreditorIdentifierFormatException if a valid Creditor Identifier could not be calculated using the
+     *                                                                           given IsoCountry, business code and creditor national id
+     */
+    public CreditorIdentifier(IsoCountry country, String businessCode, String creditorNationalId) {
+        if (country == null) {
+            throw new IllegalArgumentException("the country argument cannot be null");
+        }
+
+        if (businessCode == null) {
+            throw new IllegalArgumentException("the business code argument cannot be null");
+        }
+
+        if (creditorNationalId == null) {
+            throw new IllegalArgumentException("the creditorNationalId argument cannot be null");
+        }
+
+        String normalizedNationalId = normalize(creditorNationalId);
+        String normalizedCreditorId = country.getCode() + "00" + normalizedNationalId;
+
+        if (!isWellFormatted(normalizedCreditorId)) {
+            throw CreditorIdentifierFormatException.forNotProperlyFormattedInput(creditorNationalId);
+        }
+
+        String checkDigits = IbanCheckDigit.INSTANCE.calculate(normalizedCreditorId);
+
+        this.creditorId = country.getCode() + checkDigits + businessCode + normalizedNationalId;
+    }
+
+    /**
+     * Create a new creditor identifier from the given string.
+     *
+     * @param creditorId a non null String.
+     */
+    public CreditorIdentifier(String creditorId) {
+        if (creditorId == null) {
+            throw new IllegalArgumentException("the creditor identifier argument cannot be null");
+        }
+
+        String normalizedCreditorId = normalize(creditorId);
+
+        if (!isWellFormatted(normalizedCreditorId)) {
+            throw CreditorIdentifierFormatException.forNotProperlyFormattedInput(normalizedCreditorId);
+        }
+
+        IsoCountry country = findCountryFor(normalizedCreditorId);
+        if (country == null) {
+            throw CreditorIdentifierFormatException.forUnknownCountry(creditorId);
+        }
+
+        String normalizedCreditorIdWithoutBusinessCode = removeBusinessCode(normalizedCreditorId);
+        if (!IbanCheckDigit.INSTANCE.validate(normalizedCreditorIdWithoutBusinessCode)) {
+            throw CreditorIdentifierFormatException.forIncorrectCheckDigits(creditorId);
+        }
+
+        this.creditorId = normalizedCreditorId;
+    }
+
+    /**
+     * <p>Returns a normalized string representation of the given Creditor Identifier.</p>
+     * <p/>
+     * <p>Normalized means the string is:<ul>
+     * <li>made of uppercase characters</li>
+     * <li>contains no spaces</li>
+     * </ul></p>
+     */
+    private static String normalize(String creditorIdentifier) {
+        return creditorIdentifier.replaceAll("\\s+", "").toUpperCase();
+    }
+
+    /**
+     * <p>Check if the given string matches the basic format of a Creditor Identifier.</p>
+     * <p>Returns {@code true} if the given strings matches the following pattern:
+     * <ul>
+     * <li>Position 1-2 filled with alphabetic values (the ISO country code). </li>
+     * <li>Position 3-4 filled with numeric values (the check digits).</li>
+     * <li>Position 5-7 filled with alpha-numeric values (the Creditor Business Code).</li>
+     * <li>Position 8 onwards filled with alpha-numeric values (a national identifier of the Creditor).</li>
+     * </ul>
+     * </p>
+     */
+    private static boolean isWellFormatted(String creditorIdentifier) {
+        return BASIC_PATTERN.matcher(creditorIdentifier).matches();
+    }
+
+    /**
+     * <p>Returns the {@code Country} reference from the given Creditor Identifier string.</p>
+     * <p>Returns null if not found.</p>
+     */
+    private static IsoCountry findCountryFor(String creditorIdentifier) {
+        return IsoCountry.fromCode(creditorIdentifier.substring(COUNTRY_CODE_INDEX, COUNTRY_CODE_INDEX + COUNTRY_CODE_LENGTH));
+    }
+
+    /**
+     * <p>Removes the business code part from the given Creditor Identifier string.</p>
+     */
+    private static String removeBusinessCode(String creditorIdentifier) {
+        return creditorIdentifier.substring(COUNTRY_CODE_INDEX, CREDITOR_BUSINESS_CODE_INDEX) + creditorIdentifier.substring(CREDITOR_NATIONAL_ID_INDEX);
+    }
+
+    /**
+     * Validates the given Creditor Identifier String.
+     *
+     * @param creditorIdentifier A String.
+     * @return {@code true} if the given String is a valid Creditor Identifier, {@code false} otherwise.
+     */
+    public static boolean isValid(String creditorIdentifier) {
+        if (creditorIdentifier == null) {
+            return false;
+        }
+
+        String normalizedCreditorId = normalize(creditorIdentifier);
+
+        if (!isWellFormatted(normalizedCreditorId)) {
+            return false;
+        }
+
+        IsoCountry country = findCountryFor(normalizedCreditorId);
+        if (country == null) {
+            return false;
+        }
+
+        String normalizedCreditorIdWithoutBusinessCode = removeBusinessCode(normalizedCreditorId);
+
+        return IbanCheckDigit.INSTANCE.validate(normalizedCreditorIdWithoutBusinessCode);
+    }
+
+    /**
+     * Extract the ISO 3166-1-alpha-2 country code from this Creditor Identifier.
+     *
+     * @return A non null string representing this Creditor Identifier ISO 3166-1-alpha-2 country code.
+     */
+    public String getCountryCode() {
+        return creditorId.substring(COUNTRY_CODE_INDEX, COUNTRY_CODE_INDEX + COUNTRY_CODE_LENGTH);
+    }
+
+    /**
+     * Extract the check digit from this Creditor Identifier.
+     *
+     * @return A non null string representing this Creditor Identifier check digit.
+     */
+    public String getCheckDigit() {
+        return creditorId.substring(CHECK_DIGITS_INDEX, CHECK_DIGITS_INDEX + CHECK_DIGITS_LENGTH);
+    }
+
+    /**
+     * Extract the business code from this Creditor Identifier.
+     *
+     * @return A non null string representing this Creditor Identifier business code.
+     */
+    public String getBusinessCode() {
+        return creditorId.substring(CREDITOR_BUSINESS_CODE_INDEX, CREDITOR_BUSINESS_CODE_INDEX + CREDITOR_BUSINESS_CODE_LENGTH);
+    }
+
+    /**
+     * Extract the creditor national identifier from this Creditor Identifier.
+     *
+     * @return A non null string representing this Creditor Identifier National Id.
+     */
+    public String getNationalIdentifier() {
+        return creditorId.substring(CREDITOR_NATIONAL_ID_INDEX);
+    }
+
+    @Override
+    public String toString() {
+        return creditorId;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        CreditorIdentifier other = (CreditorIdentifier) o;
+
+        return creditorId.equals(other.creditorId);
+    }
+
+    @Override
+    public int hashCode() {
+        return creditorId.hashCode();
+    }
+
+}

--- a/src/main/java/fr/marcwrobel/jbanking/creditor/CreditorIdentifierFormatException.java
+++ b/src/main/java/fr/marcwrobel/jbanking/creditor/CreditorIdentifierFormatException.java
@@ -1,0 +1,71 @@
+/**
+ * Copyright 2013 Marc Wrobel (marc.wrobel@gmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * 		http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package fr.marcwrobel.jbanking.creditor;
+
+/**
+ * Thrown to indicate that an attempt has been made to convert a string to
+ * a {@link fr.marcwrobel.jbanking.creditor.CreditorIdentifier},
+ * but that the string does not have the appropriate format.
+ *
+ * @author Charles Kayser
+ * @see fr.marcwrobel.jbanking.creditor.CreditorIdentifier#CreditorIdentifier(String)
+ */
+public class CreditorIdentifierFormatException extends RuntimeException {
+
+    private final String inputString;
+
+    /**
+     * Constructs a <code>CreditorIdentifierFormatException</code> with the string that caused the error and the given detail message.
+     *
+     * @param input   a string
+     * @param message a string
+     */
+    public CreditorIdentifierFormatException(String input, String message) {
+        super(message);
+        this.inputString = input;
+    }
+
+    /**
+     * Creates a {@code CreditorIdentifierFormatException} telling the given Creditor Identifier is not properly formatted.
+     */
+    public static CreditorIdentifierFormatException forNotProperlyFormattedInput(String input) {
+        return new CreditorIdentifierFormatException(input, String.format("'%s' format is not appropriate for a CreditorId", input));
+    }
+
+    /**
+     * Creates a {@code CreditorIdentifierFormatException} telling the given Creditor Identifier check digits
+     * are incorrect.
+     */
+    static CreditorIdentifierFormatException forIncorrectCheckDigits(String input) {
+        return new CreditorIdentifierFormatException(input, String.format("'%s' check digits are incorrect", input));
+    }
+
+    /**
+     * Creates a {@code CreditorIdentifierFormatException} telling the given Creditor Identifier refers an unknown country.
+     */
+    static CreditorIdentifierFormatException forUnknownCountry(String input) {
+        return new CreditorIdentifierFormatException(input, String.format("'%s' country code is not an ISO 3166-1-alpha-2 code", input));
+    }
+
+    /**
+     * Returns the input String that caused this exception to be raised.
+     *
+     * @return a string
+     */
+    public String getInputString() {
+        return inputString;
+    }
+}

--- a/src/test/java/fr/marcwrobel/jbanking/creditor/CreditorIdentifierTest.java
+++ b/src/test/java/fr/marcwrobel/jbanking/creditor/CreditorIdentifierTest.java
@@ -1,0 +1,253 @@
+package fr.marcwrobel.jbanking.creditor;
+
+import com.google.common.collect.Sets;
+import fr.marcwrobel.jbanking.IsoCountry;
+import fr.marcwrobel.jbanking.TestUtils;
+import org.junit.Test;
+
+import java.util.Set;
+
+import static fr.marcwrobel.jbanking.TestUtils.shouldHaveThrown;
+import static org.junit.Assert.*;
+
+/**
+ * Tests for the {@link fr.marcwrobel.jbanking.creditor.CreditorIdentifier} class.
+ *
+ * @author Charles Kayser
+ */
+public class CreditorIdentifierTest {
+
+    private static final Set<String> VALID_CREDITOR_IDENTIFIERS = Sets.newHashSet(
+            "HR04ZZZ01234567890",
+            "SK19ZZZ70000000022",
+            "NO38ZZZ123456785",
+            "ES59ZZZX1234567L",
+            "CY54ZZZ003A",
+            "CZ56ZZZ12345",
+            "IE84ZZZ123456",
+            "FR72ZZZ123456",
+            "PL18ZZZ0123456789",
+            "DK95ZZZ999912345678",
+            "DE51ZZZ12345678901",
+            "LT30ZZZ123456789",
+            "MC54ZZZ123456",
+            "GB23ZZZSDDBARC000000ABCD1234",
+            "SE41ZZZ1234567890",
+            "ES04ZZZ52840790N",
+            "NL42ZZZ123456780001",
+            "AT61ZZZ01234567890",
+            "LV21ZZZ40003000010",
+            "BE68ZZZ0123456789",
+            "GR44ZZZ12345",
+            "IT66ZZZA1B2C3D4E5F6G7H8",
+            "PT73ZZZ123456",
+            "SI02ZZZ12345678",
+            "HU56ZZZE12345676",
+            "BE69ZZZ050D000000008",
+            "HU74111A12345676",
+            "BG07ZZZ100064095",
+            "FI22BBB12345678",
+            "SM94ZZZA1B2C3D4E5F6G7H8",
+            "ES50ZZZM23456789",
+            "LU27ZZZ0000000000123456789",
+            "CH1312300000012345",
+            "MT31ZZZ123456789X",
+            "EE49ZZZEE00012345678"
+    );
+
+    private static final String VALID_CI_COUNTRY = "FR";
+    private static final String VALID_CI_CHECKDIGIT = "72";
+    private static final String VALID_CI_BUSINESS_CODE = "ZZZ";
+    private static final String VALID_CI_NATIONAL_ID = "123456";
+    private static final String VALID_CI = VALID_CI_COUNTRY + VALID_CI_CHECKDIGIT + VALID_CI_BUSINESS_CODE + VALID_CI_NATIONAL_ID;
+    private static final String VALID_CI2 = "BE69ZZZ050D000000008";
+
+    private static final String INVALID_CI_NATIONAL_ID = "132!";
+
+    private static final String CI_WITH_INVALID_FORMAT = VALID_CI_COUNTRY + VALID_CI_CHECKDIGIT + VALID_CI_BUSINESS_CODE + INVALID_CI_NATIONAL_ID;
+    private static final String CI_WITH_UNKNOWN_COUNTRY = "ZZ" + VALID_CI_CHECKDIGIT + VALID_CI_BUSINESS_CODE + VALID_CI_NATIONAL_ID;
+    private static final String CI_WITH_UNSUPPORTED_COUNTRY = "US" + VALID_CI_CHECKDIGIT + VALID_CI_BUSINESS_CODE + VALID_CI_NATIONAL_ID;
+
+    private static final String CI_WITH_INVALID_CHECK_DIGIT = VALID_CI_COUNTRY + "01" + VALID_CI_BUSINESS_CODE + VALID_CI_NATIONAL_ID;
+
+    @Test
+    public void nullIsNotAValidCreditorIdentifier() {
+        assertFalse(CreditorIdentifier.isValid(null));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void aCreditorIdentifierCannotBeNull() {
+        new CreditorIdentifier(null);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void aCreditorIdentifierCountryCannotBeNull() {
+        new CreditorIdentifier(null, VALID_CI_BUSINESS_CODE, "123456");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void aCreditorNationalIdCannotBeNull() {
+        new CreditorIdentifier(IsoCountry.FRANCE, VALID_CI_BUSINESS_CODE, null);
+    }
+
+    @Test
+    public void blankIsNotAValidCreditorIdentifier() {
+        assertFalse(CreditorIdentifier.isValid(TestUtils.BLANK));
+    }
+
+    @Test(expected = CreditorIdentifierFormatException.class)
+    public void aCreditorIdentifierCannotBeBlank() {
+        new CreditorIdentifier(TestUtils.BLANK);
+    }
+
+    @Test(expected = CreditorIdentifierFormatException.class)
+    public void aCreditorNationalIdCannotBeBlank() {
+        new CreditorIdentifier(IsoCountry.FRANCE, VALID_CI_BUSINESS_CODE, TestUtils.BLANK);
+    }
+
+    @Test
+    public void creditorIdWithUnknownCountryIsNotValid() {
+        assertFalse(CreditorIdentifier.isValid(CI_WITH_UNKNOWN_COUNTRY));
+    }
+
+    @Test
+    public void aCreditorIdMustBeFromAKnownCountry() {
+        try {
+            new CreditorIdentifier(CI_WITH_UNKNOWN_COUNTRY);
+            shouldHaveThrown(CreditorIdentifierFormatException.class);
+        } catch (CreditorIdentifierFormatException e) {
+            assertEquals(CI_WITH_UNKNOWN_COUNTRY, e.getInputString());
+            assertTrue(e.getMessage().contains("ISO 3166-1-alpha-2 code"));
+        }
+    }
+
+    @Test
+    public void creditorIdWithUnsupportedCountryIsNotValid() {
+        assertFalse(CreditorIdentifier.isValid(CI_WITH_UNSUPPORTED_COUNTRY));
+    }
+
+    @Test
+    public void notProperlyFormattedCreditorIdentifierIsNotValid() {
+        assertFalse(CreditorIdentifier.isValid(CI_WITH_INVALID_FORMAT));
+    }
+
+    @Test
+    public void aCreditorIdMustBeProperlyFormatted() {
+        try {
+            new CreditorIdentifier(CI_WITH_INVALID_FORMAT);
+            shouldHaveThrown(CreditorIdentifierFormatException.class);
+        } catch (CreditorIdentifierFormatException e) {
+            assertEquals(CI_WITH_INVALID_FORMAT, e.getInputString());
+            assertTrue(e.getMessage().contains("format"));
+        }
+    }
+
+    @Test
+    public void aCreditorNationalIdMustBeProperlyStructured() {
+        try {
+            new CreditorIdentifier(IsoCountry.FRANCE, VALID_CI_BUSINESS_CODE, INVALID_CI_NATIONAL_ID);
+            shouldHaveThrown(CreditorIdentifierFormatException.class);
+        } catch (CreditorIdentifierFormatException e) {
+            assertEquals(INVALID_CI_NATIONAL_ID, e.getInputString());
+            assertTrue(e.getMessage().contains("format"));
+        }
+    }
+
+    @Test
+    public void aCreditorIdWithInvalidCheckDigitsIsNotValid() {
+        assertFalse(CreditorIdentifier.isValid(CI_WITH_INVALID_CHECK_DIGIT));
+    }
+
+    @Test
+    public void aCreditorIdMustHaveCorrectCheckDigit() {
+        try {
+            new CreditorIdentifier(CI_WITH_INVALID_CHECK_DIGIT);
+            shouldHaveThrown(CreditorIdentifierFormatException.class);
+        } catch (CreditorIdentifierFormatException e) {
+            assertEquals(CI_WITH_INVALID_CHECK_DIGIT, e.getInputString());
+            assertTrue(e.getMessage().contains("check digits"));
+        }
+    }
+
+    @Test
+    public void validCreditorIdentifierDecomposition() {
+        assertTrue(CreditorIdentifier.isValid(VALID_CI));
+        CreditorIdentifier creditorId = new CreditorIdentifier(VALID_CI);
+        assertEquals(VALID_CI_COUNTRY, creditorId.getCountryCode());
+        assertEquals(VALID_CI_CHECKDIGIT, creditorId.getCheckDigit());
+        assertEquals(VALID_CI_BUSINESS_CODE, creditorId.getBusinessCode());
+        assertEquals(VALID_CI_NATIONAL_ID, creditorId.getNationalIdentifier());
+    }
+
+    @Test
+    public void validCreditorIdentifiersTest() {
+        for (String creditorIdString : VALID_CREDITOR_IDENTIFIERS) {
+            assertTrue(String.format("%s should be valid", creditorIdString), CreditorIdentifier.isValid(creditorIdString));
+
+            CreditorIdentifier creditorId = new CreditorIdentifier(creditorIdString);
+            String countryCode = creditorIdString.substring(0, 2);
+            String businessCode = creditorIdString.substring(4, 7);
+            String nationalId = creditorIdString.substring(7);
+            assertEquals(String.format("%s not properly calculated", creditorId), creditorId, new CreditorIdentifier(IsoCountry.fromCode(countryCode), businessCode, nationalId));
+        }
+    }
+
+    @Test
+    public void creditorIdValidationIsNotCaseSensitive() {
+        for (String creditorId : VALID_CREDITOR_IDENTIFIERS) {
+            String lowerCaseCreditorIdentifier = creditorId.toLowerCase();
+            assertTrue(String.format("%s should be valid", lowerCaseCreditorIdentifier), CreditorIdentifier.isValid(lowerCaseCreditorIdentifier));
+        }
+    }
+
+    @Test
+    public void creditorIdCreationIsNotCaseSensitive() {
+        for (String creditorId : VALID_CREDITOR_IDENTIFIERS) {
+            new CreditorIdentifier(creditorId.toLowerCase());
+        }
+    }
+
+    @Test
+    public void creditorIdFromBbanCreationIsNotCaseSensitive() {
+        for (String creditorId : VALID_CREDITOR_IDENTIFIERS) {
+            String countryCode = creditorId.substring(0, 2);
+            String businessCode = creditorId.substring(4, 7);
+            String nationalId = creditorId.substring(7);
+            assertEquals(String.format("%s not properly calculated", creditorId), creditorId, new CreditorIdentifier(IsoCountry.fromCode(countryCode), businessCode, nationalId.toLowerCase()).toString());
+        }
+    }
+
+    @Test
+    public void printableCreditorIdentifiersAreValid() {
+        CreditorIdentifier creditorId = new CreditorIdentifier(VALID_CI);
+        String printableCreditorIdentifier = creditorId.toString();
+
+        assertTrue(CreditorIdentifier.isValid(printableCreditorIdentifier));
+        assertEquals(creditorId, new CreditorIdentifier(printableCreditorIdentifier));
+    }
+
+    @Test
+    public void equalityTest() {
+        CreditorIdentifier creditorId1 = new CreditorIdentifier(VALID_CI);
+        CreditorIdentifier creditorId2 = new CreditorIdentifier(creditorId1.toString());
+        CreditorIdentifier creditorId3 = new CreditorIdentifier(VALID_CI.toLowerCase());
+
+        assertTrue(creditorId1.equals(creditorId1));
+        assertTrue(creditorId2.equals(creditorId2));
+        assertTrue(creditorId3.equals(creditorId3));
+
+        assertTrue(creditorId1.equals(creditorId2));
+        assertTrue(creditorId2.equals(creditorId1));
+        assertTrue(creditorId2.equals(creditorId3));
+        assertTrue(creditorId3.equals(creditorId2));
+        assertTrue(creditorId1.equals(creditorId3));
+        assertTrue(creditorId3.equals(creditorId1));
+        assertTrue(creditorId1.hashCode() == creditorId2.hashCode());
+        assertTrue(creditorId2.hashCode() == creditorId3.hashCode());
+
+        assertFalse(creditorId1.equals(null));
+        assertFalse(creditorId1.equals(new Object()));
+        assertFalse(creditorId1.equals(new CreditorIdentifier(VALID_CI2)));
+    }
+
+}


### PR DESCRIPTION
Enhancement #7

This introduces the EPC Creditor Identifier class which handle basic structure validation as well as check digit validation as detailed in the last [Creditor Identifier Overview](http://www.europeanpaymentscouncil.eu/index.cfm/knowledge-bank/epc-documents/creditor-identifier-overview/) updated in september 2014.

Here's the Creditor Identifier (CI) structure and my implementation comments:
- Position 1-2 filled with the ISO country code.
  **IsoCountry class is reused for this**
- Position 3-4 filled with the check digit according to ISO 7064 Mod 97-10. 
  **IbanCheckDigit is reused as it is the same algorithm for validating a CI as it is for an Iban (business code must be removed first)**
- Position 5-7 filled with the Creditor Business Code, if not used then filled with ZZZ. 
  **The business code is validated against alpha-numeric pattern**
- Position 8 onwards filled with the country specific part of the identifier being a national identifier of the Creditor, as defined by the National Community 
  **No specific validation applied for this field.
  This enhancement doesn't go into the full validation of the Creditor National Id (which is still unclear for every SEPA country from the EPC perspective).**
