### PR TITLE
Make jbanking serializable-friendly (closes #53)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ This new release includes :
 
 ### Changed
 
-- Upgrade to Strata 2.8.1.
+- Upgrade to Strata 2.8.1 (#52).
+- Make jbanking serializable-friendly (#53).
 
 ### Fixed
 

--- a/src/main/java/fr/marcwrobel/jbanking/bic/Bic.java
+++ b/src/main/java/fr/marcwrobel/jbanking/bic/Bic.java
@@ -1,6 +1,7 @@
 package fr.marcwrobel.jbanking.bic;
 
 import fr.marcwrobel.jbanking.IsoCountry;
+import java.io.Serializable;
 import java.util.regex.Pattern;
 
 /**
@@ -26,7 +27,10 @@ import java.util.regex.Pattern;
  *     href="http://wikipedia.org/wiki/Bank_Identifier_Code">http://wikipedia.org/wiki/Bank_Identifier_Code</a>
  * @since 1.0
  */
-public final class Bic {
+public final class Bic implements Serializable {
+
+  /** Serialization version. */
+  private static final long serialVersionUID = 0;
 
   /** A simple regex that validate well-formed BIC. */
   public static final String BIC_REGEX = "[A-Za-z]{4}[A-Za-z]{2}[A-Za-z0-9]{2}([A-Za-z0-9]{3})?";

--- a/src/main/java/fr/marcwrobel/jbanking/bic/BicFormatException.java
+++ b/src/main/java/fr/marcwrobel/jbanking/bic/BicFormatException.java
@@ -10,6 +10,9 @@ package fr.marcwrobel.jbanking.bic;
  */
 public final class BicFormatException extends RuntimeException {
 
+  /** Serialization version. */
+  private static final long serialVersionUID = 0;
+
   private final String inputString;
 
   /**

--- a/src/main/java/fr/marcwrobel/jbanking/calendar/DateCalculationException.java
+++ b/src/main/java/fr/marcwrobel/jbanking/calendar/DateCalculationException.java
@@ -8,6 +8,9 @@ package fr.marcwrobel.jbanking.calendar;
  */
 public class DateCalculationException extends RuntimeException {
 
+  /** Serialization version. */
+  private static final long serialVersionUID = 0;
+
   /**
    * Creates a new instance with the given message.
    *

--- a/src/main/java/fr/marcwrobel/jbanking/creditor/CreditorIdentifier.java
+++ b/src/main/java/fr/marcwrobel/jbanking/creditor/CreditorIdentifier.java
@@ -2,6 +2,7 @@ package fr.marcwrobel.jbanking.creditor;
 
 import fr.marcwrobel.jbanking.IsoCountry;
 import fr.marcwrobel.jbanking.iban.IbanCheckDigit;
+import java.io.Serializable;
 import java.util.Optional;
 import java.util.regex.Pattern;
 
@@ -29,7 +30,10 @@ import java.util.regex.Pattern;
  *     href="http://www.europeanpaymentscouncil.eu/index.cfm/knowledge-bank/epc-documents/creditor-identifier-overview/">EPC
  *     Creditor Identifier Overview</a>
  */
-public class CreditorIdentifier {
+public class CreditorIdentifier implements Serializable {
+
+  /** Serialization version. */
+  private static final long serialVersionUID = 0;
 
   private static final String BASIC_REGEX = "[A-Za-z]{2}[0-9]{2}[A-Za-z0-9]{3}[A-Za-z0-9]+";
   private static final Pattern BASIC_PATTERN = Pattern.compile(BASIC_REGEX);

--- a/src/main/java/fr/marcwrobel/jbanking/creditor/CreditorIdentifierFormatException.java
+++ b/src/main/java/fr/marcwrobel/jbanking/creditor/CreditorIdentifierFormatException.java
@@ -10,6 +10,9 @@ package fr.marcwrobel.jbanking.creditor;
  */
 public class CreditorIdentifierFormatException extends RuntimeException {
 
+  /** Serialization version. */
+  private static final long serialVersionUID = 0;
+
   private final String inputString;
 
   /**

--- a/src/main/java/fr/marcwrobel/jbanking/iban/Iban.java
+++ b/src/main/java/fr/marcwrobel/jbanking/iban/Iban.java
@@ -1,6 +1,7 @@
 package fr.marcwrobel.jbanking.iban;
 
 import fr.marcwrobel.jbanking.IsoCountry;
+import java.io.Serializable;
 import java.util.Optional;
 import java.util.regex.Pattern;
 
@@ -26,7 +27,10 @@ import java.util.regex.Pattern;
  * @see <a href="https://www.iso13616.org">https://www.iso13616.org</a>
  * @since 1.0
  */
-public final class Iban {
+public final class Iban implements Serializable {
+
+  /** Serialization version. */
+  private static final long serialVersionUID = 0;
 
   private static final String BASIC_REGEX = "[A-Za-z]{2}[0-9]{2}[A-Za-z0-9]+";
   private static final Pattern BASIC_PATTERN = Pattern.compile(BASIC_REGEX);

--- a/src/main/java/fr/marcwrobel/jbanking/iban/IbanFormatException.java
+++ b/src/main/java/fr/marcwrobel/jbanking/iban/IbanFormatException.java
@@ -12,6 +12,9 @@ import fr.marcwrobel.jbanking.IsoCountry;
  */
 public final class IbanFormatException extends RuntimeException {
 
+  /** Serialization version. */
+  private static final long serialVersionUID = 0;
+
   private final String inputString;
 
   /**

--- a/src/main/java/fr/marcwrobel/jbanking/swift/SwiftPattern.java
+++ b/src/main/java/fr/marcwrobel/jbanking/swift/SwiftPattern.java
@@ -1,5 +1,6 @@
 package fr.marcwrobel.jbanking.swift;
 
+import java.io.Serializable;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -46,7 +47,10 @@ import java.util.regex.Pattern;
  * @see java.util.regex.Pattern
  * @since 1.0
  */
-public final class SwiftPattern {
+public final class SwiftPattern implements Serializable {
+
+  /** Serialization version. */
+  private static final long serialVersionUID = 0;
 
   static final char DIGITS_CHARACTER = 'n';
   static final char UPPER_CASE_LETTERS_CHARACTER = 'a';

--- a/src/main/java/fr/marcwrobel/jbanking/swift/SwiftPatternSyntaxException.java
+++ b/src/main/java/fr/marcwrobel/jbanking/swift/SwiftPatternSyntaxException.java
@@ -9,6 +9,9 @@ package fr.marcwrobel.jbanking.swift;
  */
 public class SwiftPatternSyntaxException extends RuntimeException {
 
+  /** Serialization version. */
+  private static final long serialVersionUID = 0;
+
   private final String expression;
 
   /**


### PR DESCRIPTION
Bic, Iban, CreditorIdentifier and SwiftPattern has been made serializable and all serializable classes, except enums, now declare a serialVersionUID field.