### PR TITLE
Use Maven --strict-checksums option by default (closes #123)

### DIFF
--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,2 +1,3 @@
 --errors
+--strict-checksums
 --show-version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,5 +36,6 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Configure CI for maintenance branches (#112).
 - Fix Sonatype lift `MissingSummary` warnings (#118).
 - Upgrade JDK version in development environment to 17 (#119).
+- Use Maven --strict-checksums option by default (#123).
 
 ### Thanks


### PR DESCRIPTION
Note that --strict-checksums will be the default in Maven 4 (https://issues.apache.org/jira/browse/MNG-5728).