### PR TITLE
Disallow @author tags in the Javadoc (closes #122)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,5 +38,6 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Upgrade JDK version in development environment to 17 (#119).
 - Use Maven --strict-checksums option by default (#123).
 - Switch to formatter-maven-plugin for code formatting (#125).
+- Disallow @author tags in the Javadoc (#122).
 
 ### Thanks

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,3 +88,6 @@ automatically execute CI in their forks as part of the process of making changes
 - Tests and documentation are not optional. Don't forget to include tests in your pull requests. Also don't forget the
   documentation (reference documentation, javadoc...).
 - Make sure to launch the full tests suite before creating your pull request.
+- `@author` tags are disallowed in the javadoc: they are hard to maintain, and we use the Git history to track
+  authorship. GitHub also has [this nice page](https://github.com/marcwrobel/jbanking/graphs/contributors) with your
+  contributions.

--- a/src/main/java/fr/marcwrobel/jbanking/Agreement.java
+++ b/src/main/java/fr/marcwrobel/jbanking/Agreement.java
@@ -11,7 +11,6 @@ import java.util.Set;
  * A list of <a href="https://en.wikipedia.org/wiki/Economic_integration">economic agreements</a> between countries or
  * territories that may be useful in banking processes (such as file processing).
  *
- * @author Marc Wrobel
  * @since 2.1.0
  */
 public enum Agreement {

--- a/src/main/java/fr/marcwrobel/jbanking/IsoCountry.java
+++ b/src/main/java/fr/marcwrobel/jbanking/IsoCountry.java
@@ -31,7 +31,6 @@ import java.util.Set;
  * Please be advised that this list is current as of 2020-08-03. An up-to-date list can be found on the
  * <a href="http://www.iso.org/iso/home/standards/country_codes.htm">International Organization for Standardization</a> website.
  *
- * @author Marc Wrobel
  * @see <a href="http://www.iso.org/iso/home/standards/country_codes.htm">ISO 3166 Country Codes</a>
  * @since 1.0
  */

--- a/src/main/java/fr/marcwrobel/jbanking/IsoCurrency.java
+++ b/src/main/java/fr/marcwrobel/jbanking/IsoCurrency.java
@@ -24,7 +24,6 @@ import java.util.*;
  * <li>prevent accidental duplicates.
  * </ul>
  *
- * @author Marc Wrobel
  * @see <a href="https://www.currency-iso.org/en/home/tables/table-a1.html">currency-iso.org</a>
  * @since 1.0
  */

--- a/src/main/java/fr/marcwrobel/jbanking/bic/Bic.java
+++ b/src/main/java/fr/marcwrobel/jbanking/bic/Bic.java
@@ -24,7 +24,6 @@ import java.util.regex.Pattern;
  * <p>
  * This class is immutable.
  *
- * @author Marc Wrobel
  * @see <a href="http://wikipedia.org/wiki/Bank_Identifier_Code">http://wikipedia.org/wiki/Bank_Identifier_Code</a>
  * @since 1.0
  */

--- a/src/main/java/fr/marcwrobel/jbanking/bic/BicFormatException.java
+++ b/src/main/java/fr/marcwrobel/jbanking/bic/BicFormatException.java
@@ -4,7 +4,6 @@ package fr.marcwrobel.jbanking.bic;
  * Thrown to indicate that an attempt has been made to convert a string to a {@link Bic}, but that the string does not have the
  * appropriate format.
  *
- * @author Marc Wrobel
  * @see Bic#Bic(String)
  * @since 1.0
  */

--- a/src/main/java/fr/marcwrobel/jbanking/calendar/BridgedHoliday.java
+++ b/src/main/java/fr/marcwrobel/jbanking/calendar/BridgedHoliday.java
@@ -10,7 +10,6 @@ import java.time.LocalDate;
  * <p>
  * This class is useful for modeling holidays like the bridged japanese holidays.
  *
- * @author Marc Wrobel
  * @since 3.1.0
  */
 public class BridgedHoliday implements Holiday {

--- a/src/main/java/fr/marcwrobel/jbanking/calendar/Calendar.java
+++ b/src/main/java/fr/marcwrobel/jbanking/calendar/Calendar.java
@@ -13,7 +13,6 @@ import java.util.Set;
  * <p>
  * Subclasses of this interface are expected to be thread-safe and immutable.
  *
- * @author Marc Wrobel
  * @since 2.1.0
  */
 public interface Calendar {

--- a/src/main/java/fr/marcwrobel/jbanking/calendar/CompositeCalendar.java
+++ b/src/main/java/fr/marcwrobel/jbanking/calendar/CompositeCalendar.java
@@ -12,7 +12,6 @@ import java.util.Set;
 /**
  * A {@link Calendar} that can combine multiple calendars into a single one.
  *
- * @author Marc Wrobel
  * @since 3.0.0
  */
 public final class CompositeCalendar implements Calendar {

--- a/src/main/java/fr/marcwrobel/jbanking/calendar/ConfigurableCalendar.java
+++ b/src/main/java/fr/marcwrobel/jbanking/calendar/ConfigurableCalendar.java
@@ -12,7 +12,6 @@ import java.util.Set;
 /**
  * A {@link Calendar} that can be programmatically configured.
  *
- * @author Marc Wrobel
  * @since 2.1.0
  */
 public final class ConfigurableCalendar implements Calendar {

--- a/src/main/java/fr/marcwrobel/jbanking/calendar/DateCalculationException.java
+++ b/src/main/java/fr/marcwrobel/jbanking/calendar/DateCalculationException.java
@@ -3,7 +3,6 @@ package fr.marcwrobel.jbanking.calendar;
 /**
  * Thrown when a date calculation was abandoned (probably because the calendar is not valid).
  *
- * @author Marc Wrobel
  * @since 2.1.0
  */
 public class DateCalculationException extends RuntimeException {

--- a/src/main/java/fr/marcwrobel/jbanking/calendar/DayOfWeekHoliday.java
+++ b/src/main/java/fr/marcwrobel/jbanking/calendar/DayOfWeekHoliday.java
@@ -11,7 +11,6 @@ import java.time.LocalDate;
  * <p>
  * This class is useful for modeling <a href="https://wikipedia.org/wiki/Workweek_and_weekend">weekends</a>.
  *
- * @author Marc Wrobel
  * @since 2.1.0
  */
 public enum DayOfWeekHoliday implements Holiday {

--- a/src/main/java/fr/marcwrobel/jbanking/calendar/DayOfWeekInMonthHoliday.java
+++ b/src/main/java/fr/marcwrobel/jbanking/calendar/DayOfWeekInMonthHoliday.java
@@ -19,7 +19,6 @@ import java.util.Objects;
  * This class is useful for modeling holidays like <a href="https://wikipedia.org/wiki/Martin_Luther_King_Jr._Day">Martin Luther
  * King Jr. Day</a>.
  *
- * @author Marc Wrobel
  * @see TemporalAdjusters#dayOfWeekInMonth(int, DayOfWeek)
  * @since 2.1.0
  */

--- a/src/main/java/fr/marcwrobel/jbanking/calendar/FinancialCalendars.java
+++ b/src/main/java/fr/marcwrobel/jbanking/calendar/FinancialCalendars.java
@@ -58,8 +58,6 @@ import java.util.Set;
  * <p>
  * Those calendars are valid from 2000 until further notice.
  *
- * @author Marc Wrobel
- *
  * @since 2.1.0
  */
 public enum FinancialCalendars implements Calendar {
@@ -305,8 +303,7 @@ public enum FinancialCalendars implements Calendar {
       // https://en.wikipedia.org/wiki/The_Emperor%27s_Birthday - Naruhito
       new YearRangeHoliday(new ShiftedHoliday(new MonthDayHoliday(FEBRUARY, 23), SUNDAY_TO_MONDAY), 2020, 2999)));
 
-  @SuppressWarnings("ImmutableEnumChecker") // ConfigurableCalendar is thread-safe (given Holidays are
-                                            // thread-safe).
+  @SuppressWarnings("ImmutableEnumChecker") // ConfigurableCalendar is thread-safe (given Holidays are thread-safe).
   private final ConfigurableCalendar calendar;
 
   private static LocalDate d(int year, int month, int day) {

--- a/src/main/java/fr/marcwrobel/jbanking/calendar/FixedHoliday.java
+++ b/src/main/java/fr/marcwrobel/jbanking/calendar/FixedHoliday.java
@@ -15,7 +15,6 @@ import java.util.Set;
  * <p>
  * This class is useful for modeling exceptional holidays like the golden jubilee in the United Kingdom.
  *
- * @author Marc Wrobel
  * @since 2.1.0
  */
 public final class FixedHoliday implements Holiday {

--- a/src/main/java/fr/marcwrobel/jbanking/calendar/Holiday.java
+++ b/src/main/java/fr/marcwrobel/jbanking/calendar/Holiday.java
@@ -9,8 +9,6 @@ import java.time.LocalDate;
  * <p>
  * Subclasses of this interface are expected to be thread-safe and immutable.
  *
- * @author Marc Wrobel
- *
  * @since 2.1.0
  */
 public interface Holiday {
@@ -19,9 +17,7 @@ public interface Holiday {
    * Check whether the given date is an occurrence of this holiday.
    *
    * @param date the date to check.
-   *
    * @return {@code true} if the given date is an occurrence of this holiday, {@code false} otherwise.
-   *
    * @throws NullPointerException if the given date is {@code null}.
    */
   boolean check(LocalDate date);

--- a/src/main/java/fr/marcwrobel/jbanking/calendar/MonthDayHoliday.java
+++ b/src/main/java/fr/marcwrobel/jbanking/calendar/MonthDayHoliday.java
@@ -13,7 +13,6 @@ import java.util.Objects;
  * <p>
  * This class is useful for modeling holidays like Christmas.
  *
- * @author Marc Wrobel
  * @since 2.1.0
  */
 public final class MonthDayHoliday implements Holiday {

--- a/src/main/java/fr/marcwrobel/jbanking/calendar/MovedHoliday.java
+++ b/src/main/java/fr/marcwrobel/jbanking/calendar/MovedHoliday.java
@@ -15,7 +15,6 @@ import java.util.Objects;
  * This class is useful for modeling holidays like the May Day in the United Kingdom, that has been exceptionally moved from
  * 2020-05-04 to 2020-05-08 in 2020 to coincide with Victory in Europe Day.
  *
- * @author Marc Wrobel
  * @since 2.1.0
  */
 public final class MovedHoliday implements Holiday {

--- a/src/main/java/fr/marcwrobel/jbanking/calendar/RelativeHoliday.java
+++ b/src/main/java/fr/marcwrobel/jbanking/calendar/RelativeHoliday.java
@@ -12,7 +12,6 @@ import java.util.Objects;
  * This class is modeling holidays like <a href="https://wikipedia.org/wiki/Easter_Monday">easter monday</a> or
  * <a href="https://wikipedia.org/wiki/Good_Friday">good friday</a>.
  *
- * @author Marc Wrobel
  * @since 2.1.0
  */
 public final class RelativeHoliday implements Holiday {

--- a/src/main/java/fr/marcwrobel/jbanking/calendar/ShiftedHoliday.java
+++ b/src/main/java/fr/marcwrobel/jbanking/calendar/ShiftedHoliday.java
@@ -12,7 +12,6 @@ import java.util.Objects;
  * This class is modeling holidays like <a href="https://wikipedia.org/wiki/Independence_Day_%28United_States%29">the
  * Independence Day</a> in the United States.
  *
- * @author Marc Wrobel
  * @since 2.1.0
  */
 public final class ShiftedHoliday implements Holiday {

--- a/src/main/java/fr/marcwrobel/jbanking/calendar/ShiftingStrategy.java
+++ b/src/main/java/fr/marcwrobel/jbanking/calendar/ShiftingStrategy.java
@@ -6,7 +6,6 @@ import java.time.LocalDate;
 /**
  * Holidays shifting strategies.
  *
- * @author Marc Wrobel
  * @since 2.1.0
  */
 public enum ShiftingStrategy {

--- a/src/main/java/fr/marcwrobel/jbanking/calendar/SuppressedHoliday.java
+++ b/src/main/java/fr/marcwrobel/jbanking/calendar/SuppressedHoliday.java
@@ -16,7 +16,6 @@ import java.util.Set;
  * This class is useful for modeling holidays like the Spring public holiday in the United Kingdom, that has been exceptionally
  * suppressed in 2002 and 2012 for the golden and diamond jubilee.
  *
- * @author Marc Wrobel
  * @since 2.1.0
  */
 public final class SuppressedHoliday implements Holiday {

--- a/src/main/java/fr/marcwrobel/jbanking/calendar/WesternEaster.java
+++ b/src/main/java/fr/marcwrobel/jbanking/calendar/WesternEaster.java
@@ -8,7 +8,6 @@ import java.time.LocalDate;
  * <p>
  * The date of Easter Sunday is computed with the Meeus/Jones/Butcher Gregorian algorithm.
  *
- * @author Marc Wrobel
  * @see <a href="http://wikipedia.org/wiki/Computus#Meeus.2FJones.2FButcher_Gregorian_algorithm">Meeus/Jones/Butcher Gregorian
  *      algorithm</a>
  * @since 2.1.0

--- a/src/main/java/fr/marcwrobel/jbanking/calendar/YearRangeHoliday.java
+++ b/src/main/java/fr/marcwrobel/jbanking/calendar/YearRangeHoliday.java
@@ -13,7 +13,6 @@ import java.util.Objects;
  * This class is useful for modeling holidays like the German reformation day that was exceptionally a national holiday in 2017
  * because of 500 anniversary of the religious reformation in Europe.
  *
- * @author Marc Wrobel
  * @since 2.1.0
  */
 public final class YearRangeHoliday implements Holiday {

--- a/src/main/java/fr/marcwrobel/jbanking/creditor/CreditorIdentifier.java
+++ b/src/main/java/fr/marcwrobel/jbanking/creditor/CreditorIdentifier.java
@@ -28,7 +28,6 @@ import java.util.regex.Pattern;
  * <p>
  * Instances of this class are immutable and are safe for use by multiple concurrent threads.
  *
- * @author Charles Kayser
  * @see <a href="http://www.europeanpaymentscouncil.eu/index.cfm/knowledge-bank/epc-documents/creditor-identifier-overview/">EPC
  *      Creditor Identifier Overview</a>
  */

--- a/src/main/java/fr/marcwrobel/jbanking/creditor/CreditorIdentifierFormatException.java
+++ b/src/main/java/fr/marcwrobel/jbanking/creditor/CreditorIdentifierFormatException.java
@@ -4,7 +4,6 @@ package fr.marcwrobel.jbanking.creditor;
  * Thrown to indicate that an attempt has been made to convert a string to a
  * {@link fr.marcwrobel.jbanking.creditor.CreditorIdentifier}, but that the string does not have the appropriate format.
  *
- * @author Charles Kayser
  * @see fr.marcwrobel.jbanking.creditor.CreditorIdentifier#CreditorIdentifier(String)
  */
 public class CreditorIdentifierFormatException extends RuntimeException {

--- a/src/main/java/fr/marcwrobel/jbanking/iban/BbanStructure.java
+++ b/src/main/java/fr/marcwrobel/jbanking/iban/BbanStructure.java
@@ -28,8 +28,6 @@ import java.util.*;
  * It is based on the document <i>IBAN REGISTRY Release 88</i> issued by SWIFT in September 2020 and was last reviewed on
  * 2020-10-18.
  *
- * @author Marc Wrobel
- * @author Matthias Kay
  * @see <a href="https://www.iso13616.org">https://www.iso13616.org</a>
  * @since 1.0
  */

--- a/src/main/java/fr/marcwrobel/jbanking/iban/Iban.java
+++ b/src/main/java/fr/marcwrobel/jbanking/iban/Iban.java
@@ -21,7 +21,6 @@ import java.util.regex.Pattern;
  * <p>
  * Instances of this class are immutable and are safe for use by multiple concurrent threads.
  *
- * @author Marc Wrobel
  * @see BbanStructure
  * @see <a href=
  *      "http://wikipedia.org/wiki/International_Bank_Account_Number">http://wikipedia.org/wiki/International_Bank_Account_Number</a>

--- a/src/main/java/fr/marcwrobel/jbanking/iban/IbanCheckDigit.java
+++ b/src/main/java/fr/marcwrobel/jbanking/iban/IbanCheckDigit.java
@@ -8,7 +8,6 @@ package fr.marcwrobel.jbanking.iban;
  * "https://git.apache.org/repos/asf?p=commons-validator.git;a=blob;f=src/main/java/org/apache/commons/validator/routines/checkdigit/IBANCheckDigit.java;hb=HEAD">Apache
  * commons-validator's IBANCheckDigit</a>.
  *
- * @author Marc Wrobel
  * @see <a href="https://en.wikipedia.org/wiki/ISO/IEC_7064">https://en.wikipedia.org/wiki/ISO/IEC_7064</a>
  * @see <a href=
  *      "https://en.wikipedia.org/wiki/International_Bank_Account_Number">https://en.wikipedia.org/wiki/International_Bank_Account_Number</a>

--- a/src/main/java/fr/marcwrobel/jbanking/iban/IbanFormatException.java
+++ b/src/main/java/fr/marcwrobel/jbanking/iban/IbanFormatException.java
@@ -6,7 +6,6 @@ import fr.marcwrobel.jbanking.IsoCountry;
  * Thrown to indicate that an attempt has been made to convert a string to a {@link Iban}, but that the string does not have the
  * appropriate format.
  *
- * @author Marc Wrobel
  * @see Iban#Iban(String)
  * @since 1.0
  */

--- a/src/main/java/fr/marcwrobel/jbanking/swift/SwiftPattern.java
+++ b/src/main/java/fr/marcwrobel/jbanking/swift/SwiftPattern.java
@@ -67,7 +67,6 @@ import java.util.regex.Pattern;
  * <p>
  * Instances of this class are immutable and are safe for use by multiple concurrent threads.
  *
- * @author Marc Wrobel
  * @see java.util.regex.Pattern
  * @since 1.0
  */

--- a/src/main/java/fr/marcwrobel/jbanking/swift/SwiftPatternSyntaxException.java
+++ b/src/main/java/fr/marcwrobel/jbanking/swift/SwiftPatternSyntaxException.java
@@ -3,7 +3,6 @@ package fr.marcwrobel.jbanking.swift;
 /**
  * Thrown to indicate a syntax error in a SWIFT expression pattern.
  *
- * @author Marc Wrobel
  * @see SwiftPattern
  * @since 1.0
  */

--- a/src/test/java/fr/marcwrobel/jbanking/IsoCountryTest.java
+++ b/src/test/java/fr/marcwrobel/jbanking/IsoCountryTest.java
@@ -24,8 +24,6 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Tests for the {@link IsoCountry} class.
- *
- * @author Marc Wrobel
  */
 class IsoCountryTest {
 

--- a/src/test/java/fr/marcwrobel/jbanking/IsoCurrencyTest.java
+++ b/src/test/java/fr/marcwrobel/jbanking/IsoCurrencyTest.java
@@ -22,8 +22,6 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Tests for the {@link IsoCountry} class.
- *
- * @author Marc Wrobel
  */
 class IsoCurrencyTest {
 

--- a/src/test/java/fr/marcwrobel/jbanking/TestUtils.java
+++ b/src/test/java/fr/marcwrobel/jbanking/TestUtils.java
@@ -4,8 +4,6 @@ import org.junit.jupiter.api.Assertions;
 
 /**
  * Some test utilities.
- *
- * @author Marc Wrobel
  */
 public class TestUtils {
 

--- a/src/test/java/fr/marcwrobel/jbanking/bic/BicTest.java
+++ b/src/test/java/fr/marcwrobel/jbanking/bic/BicTest.java
@@ -14,8 +14,6 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Tests for the {@link Bic} class.
- *
- * @author Marc Wrobel
  */
 class BicTest {
 

--- a/src/test/java/fr/marcwrobel/jbanking/creditor/CreditorIdentifierTest.java
+++ b/src/test/java/fr/marcwrobel/jbanking/creditor/CreditorIdentifierTest.java
@@ -21,8 +21,6 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 /**
  * Tests for the {@link fr.marcwrobel.jbanking.creditor.CreditorIdentifier} class.
- *
- * @author Charles Kayser
  */
 class CreditorIdentifierTest {
 

--- a/src/test/java/fr/marcwrobel/jbanking/iban/BbanStructureTest.java
+++ b/src/test/java/fr/marcwrobel/jbanking/iban/BbanStructureTest.java
@@ -13,8 +13,6 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Tests for the {@link BbanStructure} enum.
- *
- * @author Marc Wrobel
  */
 class BbanStructureTest {
 

--- a/src/test/java/fr/marcwrobel/jbanking/iban/IbanCheckDigitTest.java
+++ b/src/test/java/fr/marcwrobel/jbanking/iban/IbanCheckDigitTest.java
@@ -15,8 +15,6 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 /**
  * Tests for the {@link IbanCheckDigit} class.
- *
- * @author Marc Wrobel
  */
 class IbanCheckDigitTest {
 

--- a/src/test/java/fr/marcwrobel/jbanking/iban/IbanTest.java
+++ b/src/test/java/fr/marcwrobel/jbanking/iban/IbanTest.java
@@ -20,8 +20,6 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 /**
  * Tests for the {@link Iban} class.
- *
- * @author Marc Wrobel
  */
 class IbanTest {
 

--- a/src/test/java/fr/marcwrobel/jbanking/swift/SwiftPatternTest.java
+++ b/src/test/java/fr/marcwrobel/jbanking/swift/SwiftPatternTest.java
@@ -11,8 +11,6 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Tests for the {@link SwiftPattern} class.
- *
- * @author Marc Wrobel
  */
 class SwiftPatternTest {
 


### PR DESCRIPTION
We decided to disallow `@author` tags in the Javadoc: they are hard to maintain, and we use the Git history to track authorship.