### PR TITLE
Make IbanCheckDigit#validate not raise an exception anymore on invalid check digit (closes #183)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- (**breaking change**) `Iban.isValid(String)` or `IbanCheckDigit.validate(String)` return `false` instead of raising an
+  `IllegalArgumentException` with invalid IBAN check digit (e.g. `00`, `01`, or `99`).
+
 ### Deprecated
 
 ### Removed

--- a/src/main/java/fr/marcwrobel/jbanking/iban/IbanCheckDigit.java
+++ b/src/main/java/fr/marcwrobel/jbanking/iban/IbanCheckDigit.java
@@ -29,6 +29,9 @@ public enum IbanCheckDigit {
 
   /**
    * Validate the given IBAN check digit.
+   * <p>
+   * The behavior of this method changed in 4.0.0: prior to this version this method raised an exception on invalid
+   * check digits. Now it is returning {@code false} instead.
    *
    * @param iban a non-null string.
    * @return {@code true} if the given IBAN check digit is valid, {@code false} otherwise.
@@ -36,20 +39,16 @@ public enum IbanCheckDigit {
    */
   public boolean validate(String iban) {
     validateString(iban);
-    validateCheckDigit(iban);
-    return modulus(iban) == CHECK_DIGITS_REMAINDER;
-  }
 
-  // It is easier to extract the check digit string and compare it with the invalid check digits,
-  // but
-  // we want to avoid unnecessary objects creation.
-  private void validateCheckDigit(String iban) {
-    char first = iban.charAt(BBAN_INDEX - 2);
-    char second = iban.charAt(BBAN_INDEX - 1);
-
-    if ((first == '0' && (second == '0' || second == '1')) || (first == '9' && second == '9')) {
-      throw new IllegalArgumentException("the check digit cannot be one of 00, 01 or 99");
+    // It is easier to extract the check digit string and compare it with the invalid check digits, but we want to avoid
+    // unnecessary objects creation.
+    char firstChar = iban.charAt(BBAN_INDEX - 2);
+    char secondChar = iban.charAt(BBAN_INDEX - 1);
+    if ((firstChar == '0' && (secondChar == '0' || secondChar == '1')) || (firstChar == '9' && secondChar == '9')) {
+      return false;
     }
+
+    return modulus(iban) == CHECK_DIGITS_REMAINDER;
   }
 
   /**

--- a/src/test/java/fr/marcwrobel/jbanking/iban/IbanCheckDigitTest.java
+++ b/src/test/java/fr/marcwrobel/jbanking/iban/IbanCheckDigitTest.java
@@ -42,7 +42,7 @@ class IbanCheckDigitTest {
       "YY62DRWQ354548673SC833V5AMLYPNNR78", "ZZ70JJXD3109729650459XALAO5L68UDTR1");
 
   private static final Set<String> INVALID_CHECK_DIGIT_IBANS = Sets.newHashSet("MD006JK24D0RFGDJJPJQHKWN",
-      "MD016JK24D0RFGDJJPJQHKWN", "MD996JK24D0RFGDJJPJQHKWN");
+      "MD016JK24D0RFGDJJPJQHKWN", "MD996JK24D0RFGDJJPJQHKWN", "BY00NBRB3600000000000Z00AB00");
 
   @Test
   void nullIsNotValidForCalculation() {
@@ -66,8 +66,8 @@ class IbanCheckDigitTest {
 
   @ParameterizedTest
   @MethodSource("invalidCheckDigitIbans")
-  void invalidCheckDigitRaiseAnException(String iban) {
-    assertThrows(IllegalArgumentException.class, () -> IbanCheckDigit.INSTANCE.validate(iban));
+  void invalidCheckDigitAreNotValid(String iban) {
+    assertFalse(IbanCheckDigit.INSTANCE.validate(iban));
   }
 
   @ParameterizedTest

--- a/src/test/java/fr/marcwrobel/jbanking/iban/IbanTest.java
+++ b/src/test/java/fr/marcwrobel/jbanking/iban/IbanTest.java
@@ -17,6 +17,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 /**
  * Tests for the {@link Iban} class.
@@ -61,7 +62,8 @@ class IbanTest {
 
   private static final String IBAN_WITH_UNKNOWN_COUNTRY = "ZZ" + VALID_IBAN_CHECKDIGIT + VALID_IBAN_BBAN;
   private static final String IBAN_WITH_UNSUPPORTED_COUNTRY = "US" + VALID_IBAN_CHECKDIGIT + VALID_IBAN_BBAN;
-  private static final String IBAN_WITH_INVALID_CHECK_DIGIT = VALID_IBAN_COUNTRY.getAlpha2Code() + "09" + VALID_IBAN_BBAN;
+  private static final String IBAN_WITH_INVALID_CHECK_DIGIT = "FR0920041010050500013M02606";
+  private static final String IBAN_WITH_INVALID_CHECK_DIGIT_2 = "BY00NBRB3600000000000Z00AB00";
 
   private static final String IBAN_WITH_INVALID_BBAN_STRUCTURE = "GB72MIDLA0051539024150";
 
@@ -186,18 +188,20 @@ class IbanTest {
     }
   }
 
-  @Test
-  void anIbanWithInvalidCheckDigitsIsNotValid() {
-    assertFalse(Iban.isValid(IBAN_WITH_INVALID_CHECK_DIGIT));
+  @ParameterizedTest
+  @ValueSource(strings = { IBAN_WITH_INVALID_CHECK_DIGIT, IBAN_WITH_INVALID_CHECK_DIGIT_2 })
+  void anIbanWithInvalidCheckDigitsIsNotValid(String iban) {
+    assertFalse(Iban.isValid(iban));
   }
 
-  @Test
-  void anIbanMustHaveCorrectCheckDigit() {
+  @ParameterizedTest
+  @ValueSource(strings = { IBAN_WITH_INVALID_CHECK_DIGIT, IBAN_WITH_INVALID_CHECK_DIGIT_2 })
+  void anIbanMustHaveCorrectCheckDigit(String iban) {
     try {
-      new Iban(IBAN_WITH_INVALID_CHECK_DIGIT);
+      new Iban(iban);
       shouldHaveThrown(IbanFormatException.class);
     } catch (IbanFormatException e) {
-      assertEquals(IBAN_WITH_INVALID_CHECK_DIGIT, e.getInputString());
+      assertEquals(iban, e.getInputString());
       assertTrue(e.getMessage().contains("check digits"));
     }
   }


### PR DESCRIPTION
Instead of raising an exception this method now simply returns false in those situations.