### PR TITLE
Make `IbanCheckDigit#validate` return `false` for all invalid strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   the `SwiftPattern` rewrite. And because this feature is probably not used outside of jbanking code, we choose to drop
   it. But if you were using it, please let us know by [raising an issue](https://github.com/marcwrobel/jbanking/issues),
   so we can add it back.
+- (**breaking change**) Make `IbanCheckDigit#validate` return `false` for `null` or less than 5 characters strings
+  (#188).
 - Get rid of regexes to validate BICs (#170). This significantly increased the performances of BIC validation and
   creation (+200-300%).
 - Get rid of regexes to validate Creditor Identifiers (#172). This significantly increased the performances of

--- a/src/main/java/fr/marcwrobel/jbanking/iban/IbanCheckDigit.java
+++ b/src/main/java/fr/marcwrobel/jbanking/iban/IbanCheckDigit.java
@@ -38,7 +38,9 @@ public enum IbanCheckDigit {
    * @throws IllegalArgumentException if the given IBAN is {@code null} or if its size is not at least four characters.
    */
   public boolean validate(String iban) {
-    validateString(iban);
+    if (iban == null || iban.length() <= BBAN_INDEX) {
+      return false;
+    }
 
     // It is easier to extract the check digit string and compare it with the invalid check digits, but we want to avoid
     // unnecessary objects creation.
@@ -59,16 +61,6 @@ public enum IbanCheckDigit {
    * @return the given IBAN check digit.
    */
   public String calculate(String iban) {
-    validateString(iban);
-
-    int modulusResult = modulus(iban);
-    int charValue = (98 - modulusResult);
-    String checkDigit = Integer.toString(charValue);
-
-    return (charValue > 9 ? checkDigit : "0" + checkDigit);
-  }
-
-  private void validateString(String iban) {
     if (iban == null) {
       throw new IllegalArgumentException("the iban argument cannot be null");
     }
@@ -76,6 +68,12 @@ public enum IbanCheckDigit {
     if (iban.length() <= BBAN_INDEX) {
       throw new IllegalArgumentException("the iban argument size must be greater than " + BBAN_INDEX);
     }
+
+    int modulusResult = modulus(iban);
+    int charValue = (98 - modulusResult);
+    String checkDigit = Integer.toString(charValue);
+
+    return (charValue > 9 ? checkDigit : "0" + checkDigit);
   }
 
   private int modulus(String iban) {

--- a/src/test/java/fr/marcwrobel/jbanking/iban/IbanCheckDigitTest.java
+++ b/src/test/java/fr/marcwrobel/jbanking/iban/IbanCheckDigitTest.java
@@ -50,8 +50,8 @@ class IbanCheckDigitTest {
   }
 
   @Test
-  void nullIsNotValidForValidation() {
-    assertThrows(IllegalArgumentException.class, () -> IbanCheckDigit.INSTANCE.validate(null));
+  void nullIsNotValid() {
+    assertFalse(IbanCheckDigit.INSTANCE.validate(null));
   }
 
   @Test
@@ -60,8 +60,8 @@ class IbanCheckDigitTest {
   }
 
   @Test
-  void ibanSizeLowerThanFourIsIsNotValidForValidation() {
-    assertThrows(IllegalArgumentException.class, () -> IbanCheckDigit.INSTANCE.validate("123"));
+  void ibanSizeLowerThanFourIsNotValid() {
+    assertFalse(IbanCheckDigit.INSTANCE.validate("123"));
   }
 
   @ParameterizedTest


### PR DESCRIPTION
It does not make sense to raise an exception in a validation method that returns a boolean.