### PR TITLE
Bump parent from 2.7.0 to 2.7.1 (#241)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,5 +16,6 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Internal
 
 - Bump github/codeql-action from 2.1.28 to 2.1.29 (#240).
+- Bump parent from 2.7.0 to 2.7.1 (#241).
 
 ### Thanks

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>parent</artifactId>
     <groupId>fr.marcwrobel</groupId>
-    <version>2.7.0</version>
+    <version>2.7.1</version>
   </parent>
 
   <artifactId>jbanking</artifactId>


### PR DESCRIPTION
Changelog: https://github.com/marcwrobel/parent/releases/tag/v2.7.1.