### PR TITLE
Bump parent from 3.0.2 to 3.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   #312, #315, #317, #321, #322, #325, #326, #328, #329, #335)
 - Bump cyclonedx-maven-plugin from 2.7.4 to 2.7.5 (#304)
 - Bump strata-basics from 2.12.17 to 2.12.24 (#285, #288, #289, #311, #330, #332, #333)
-- Bump parent from 3.0.0 to 3.0.2 (#306, #331).
+- Bump parent from 3.0.0 to 3.1.0 (#306, #331, #344).
 - Bump maven from 3.8.6 to 3.9.0 in `.tool-versions` (#306).
 - Update build workflow to use Java 20 instead of Java 19 (#336)
 - Bump java from 17.0.5 to 17.0.7 (#340).

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>parent</artifactId>
     <groupId>fr.marcwrobel</groupId>
-    <version>3.0.2</version>
+    <version>3.1.0</version>
   </parent>
 
   <artifactId>jbanking</artifactId>
@@ -17,7 +17,7 @@
   <inceptionYear>2013</inceptionYear>
 
   <properties>
-    <this.java.version>1.8</this.java.version>
+    <this.java.version>8</this.java.version>
     <!-- Remove once Maven has been updated on GitPod -->
     <this.maven.version.enforced>[3.8.6,)</this.maven.version.enforced>
 


### PR DESCRIPTION
`this.java.version` has to be updated from `1.8` to `8`. `spring-boot-starter-parent` now make use of the `maven.compiler.release` property, which follow the new version naming scheme adopted since Java 9 (https://maven.apache.org/plugins/maven-compiler-plugin/examples/set-compiler-release.html).