### PR TITLE
Use only major version for GitHub-managed actions (#480)

### DIFF
--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -23,25 +23,25 @@ jobs:
     runs-on: 'ubuntu-latest'
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of sonar analysis
 
       - name: Set up Java
-        uses: actions/setup-java@8df1039502a15bceb9433410b1a100fbe190c53b # v4.5.0
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: 17
 
       - name: Cache SonarQube packages
-        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
+        uses: actions/cache@v4
         with:
           path: '~/.sonar/cache'
           key: ${{ runner.os }}-sonar
           restore-keys: ${{ runner.os }}-sonar
 
       - name: Cache Maven packages
-        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
+        uses: actions/cache@v4
         with:
           path: '~/.m2/repository'
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
@@ -57,19 +57,19 @@ jobs:
     runs-on: 'ubuntu-latest'
     steps:
       - name: Checkout repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@v4
         with:
           # We must fetch at least the immediate parents so that if this is a pull request then we can check out the head.
           fetch-depth: 2
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@aa578102511db1f4524ed59b8cc2bae4f6e88195 # v3.27.6
+        uses: github/codeql-action/init@v3
         with:
           languages: 'java'
           queries: 'security-and-quality'
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@aa578102511db1f4524ed59b8cc2bae4f6e88195 # v3.27.6
+        uses: github/codeql-action/autobuild@v3
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@aa578102511db1f4524ed59b8cc2bae4f6e88195 # v3.27.6
+        uses: github/codeql-action/analyze@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,10 +20,10 @@ jobs:
         java: ['8', '11', '17', '21']
     steps:
       - name: Checkout repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@v4
 
       - name: Set up Java ${{ matrix.java }}
-        uses: actions/setup-java@8df1039502a15bceb9433410b1a100fbe190c53b # v4.5.0
+        uses: actions/setup-java@v4
         with:
           distribution: 'zulu'
           java-version: ${{ matrix.java }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,10 +17,11 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Bump com.opengamma.strata:strata-basics from 2.12.28 to 2.12.46 (#376, #379, #383, #386, #392, #396, #405, #412, #453).
 - Bump com.google.guava:guava from 32.1.3 to 33.3.1 (#378, #390, #398, #403, #420, #428).
-- Bump actions/setup-java from 3.13.0 to 4.5.0 (#374, #389, #416, #425, #444).
-- Bump actions/cache from 3.3.2 to 4.2.0 (#381, #385, #391, #455).
-- Bump actions/checkout from 4.1.1 to 4.2.2 (#387, #397, #400, #407, #443).
-- Bump github/codeql-action from 2.13.4 to 3.27.6 (#401, #409, #417, #427, #454).
+- Bump actions/setup-java from 3.13.0 to v4 (#374, #389, #416, #425, #444).
+- Bump actions/cache from 3.3.2 to v4 (#381, #385, #391, #455).
+- Bump actions/checkout from 4.1.1 to v4 (#387, #397, #400, #407, #443).
+- Bump github/codeql-action from 2.13.4 to v3 (#401, #409, #417, #427, #454).
+- Use only major versions for GitHub-managed actions (#480).
 - Bump internal Java version from 17.0.8 to 17.0.14 (#479).
 
 ### Thanks


### PR DESCRIPTION
There is no security risk for those actions and it's easier to manage.