### PR TITLE
chore: use sonar.token instead of deprecated sonar.login in Maven settings

### DIFF
--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Analyze
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SONAR_LOGIN: ${{ secrets.SONAR_LOGIN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: 'mvn --settings .mvn/settings.xml -B -P analyze verify sonar:sonar'
 
   codeql:

--- a/.mvn/settings.xml
+++ b/.mvn/settings.xml
@@ -10,7 +10,7 @@
         <activeByDefault>true</activeByDefault>
       </activation>
       <properties>
-        <sonar.login>${env.SONAR_LOGIN}</sonar.login>
+        <sonar.token>${env.SONAR_TOKEN}</sonar.token>
       </properties>
     </profile>
   </profiles>


### PR DESCRIPTION
See https://community.sonarsource.com/t/sonar-login-is-deprecated-and-will-be-removed-in-the-future/137134.