### PR TITLE
docs: add Conventional Commits requirement to contributing guidelines

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,13 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    commit-message:
+      prefix: "chore(deps)"
+      prefix-development: "chore(deps-dev)"
+
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "daily"
+    commit-message:
+      prefix: "chore(ci)"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -144,6 +144,7 @@ All submissions need to be reviewed by at least one jbanking committer before be
 - Commits should be atomic and semantic.
   Please properly squash your pull requests before submitting them.
   Fixup commits can be used temporarily during the review process, but things should be squashed at the end to have meaningful commits.
+- Commit messages must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.
 - Git authorship (i.e., git `user.name` and `user.email`) must be properly set.
 - Tests and documentation are not optional.
   Remember to include tests in your pull requests.


### PR DESCRIPTION
Configure Dependabot to use conventional commit prefixes for its automated dependency and CI updates.